### PR TITLE
Fix logging failure

### DIFF
--- a/lib/logstash/outputs/azure_loganalytics.rb
+++ b/lib/logstash/outputs/azure_loganalytics.rb
@@ -86,10 +86,10 @@ class LogStash::Outputs::AzureLogAnalytics < LogStash::Outputs::Base
     begin
       res = @client.post_data(@log_type, documents, @time_generated_field)
       if not Azure::Loganalytics::Datacollectorapi::Client.is_success(res)
-        $logger.error("DataCollector API request failure: error code: #{res.code}, data=>" + (documents.to_json).to_s)
+        @logger.error("DataCollector API request failure: error code: #{res.code}, data=>" + (documents.to_json).to_s)
       end
     rescue Exception => ex
-      $logger.error("Exception occured in posting to DataCollector API: '#{ex}', data=>" + (documents.to_json).to_s)
+      @logger.error("Exception occured in posting to DataCollector API: '#{ex}', data=>" + (documents.to_json).to_s)
     end
 
   end # def flush


### PR DESCRIPTION
`logger` is an instance variable, not a global variable, so we were seeing "NoMethodError" exceptions when `$logger.error` was being used. Changing `$logger` to `@logger` fixed the problem and we could see logs in the logstash logs.

We are running logstash 6.5.4.