### PR TITLE
Added additional debug logging for successful requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,37 @@ Here is an expected output for sample input (Apache2 access log):
 }
 ```
 
+## Debugging
+If you need to debug and watch what this plugin is sending to Log Analytics, you can change the logstash log level for this plugin to `DEBUG` to get additional logs in the logstash logs.
+
+One way of changing the log level is to use the logstash API:
+
+```
+> curl -XPUT 'localhost:9600/_node/logging?pretty' -H "Content-Type: application/json" -d '{ "logger.logstash.outputs.azureloganalytcs" : "DEBUG" }'
+{
+  "host" : "yoichitest01",
+  "version" : "6.5.4",
+  "http_address" : "127.0.0.1:9600",
+  "id" : "d8038a9e-02c6-411a-9f6b-597f910edc54",
+  "name" : "yoichitest01",
+  "acknowledged" : true
+}
+```
+
+You should then be able to see logs like this in your logstash logs:
+
+```
+[2019-03-29T01:18:52,652][DEBUG][logstash.outputs.azureloganalytics] Posting log batch (log count: 50) as log type HealthCheckLogs to DataCollector API. First log: {"message":{"Application":"HealthCheck.API","Environments":{},"Name":"SystemMetrics","LogLevel":"Information","Properties":{"CPU":3,"Memory":83}},"beat":{"version":"6.5.4","hostname":"yoichitest01","name":"yoichitest01"},"timestamp":"2019-03-29T01:18:51.901Z"}
+
+[2019-03-29T01:18:52,819][DEBUG][logstash.outputs.azureloganalytics] Successfully posted logs as log type HealthCheckLogs with result code 200 to DataCollector API
+```
+
+Once you're done, you can use the logstash API to undo your log level changes:
+
+```
+> curl -XPUT 'localhost:9600/_node/logging/reset?pretty'
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/yokawasa/logstash-output-azure_loganalytics.

--- a/lib/logstash/outputs/azure_loganalytics.rb
+++ b/lib/logstash/outputs/azure_loganalytics.rb
@@ -80,12 +80,16 @@ class LogStash::Outputs::AzureLogAnalytics < LogStash::Outputs::Base
 
     # Skip in case there are no candidate documents to deliver
     if documents.length < 1
+      @logger.debug("No documents in batch for log type #{@log_type}. Skipping")
       return
     end
 
     begin
+      @logger.debug("Posting log batch (log count: #{documents.length}) as log type #{@log_type} to DataCollector API. First log: " + (documents[0].to_json).to_s)
       res = @client.post_data(@log_type, documents, @time_generated_field)
-      if not Azure::Loganalytics::Datacollectorapi::Client.is_success(res)
+      if Azure::Loganalytics::Datacollectorapi::Client.is_success(res)
+        @logger.debug("Successfully posted logs as log type #{@log_type} with result code #{res.code} to DataCollector API")
+      else
         @logger.error("DataCollector API request failure: error code: #{res.code}, data=>" + (documents.to_json).to_s)
       end
     rescue Exception => ex


### PR DESCRIPTION
We needed a way to see if this plugin was successfully sending data to Log Analytics, and to sample what some of the logs it was sending looked like. (Mainly because we're having issues with our logs not showing up in Log Analytics). So I added a few debug log lines to the plugin code:

* One before the data is posted to the API which prints out the first log being sent
* One after the data has been posted, with the API response code
* Also one if the batch size is 0, just in case that was happening

I set the log level for these logs to debug, because most of the time you won't want to see these logs and they are very noisy.

I've also added to the readme with some guidance on how to increase the log level in order to see these logs.