### PR TITLE
Fixed using sprintf in log_type

### DIFF
--- a/lib/logstash/outputs/azure_loganalytics.rb
+++ b/lib/logstash/outputs/azure_loganalytics.rb
@@ -84,10 +84,6 @@ class LogStash::Outputs::AzureLogAnalytics < LogStash::Outputs::Base
       document = {}
       
       log_type_for_event = event.sprintf(@log_type)
-      if log_type_for_event.match(/[^a-zA-Z0-9_]/) or log_type_for_event.length > 100
-        @logger.error("Unable to process event, rendered log_type must only contain alphanumeric and underscore chars and be <= 100 chars long. Was: '" + log_type_for_event + "', Event data => " + (event.to_json).to_s)
-        next
-      end
 
       event_hash = event.to_hash()
       if @key_names.length > 0


### PR DESCRIPTION
Recently the `log_type` parameter was enhanced to support using sprintf strings (#13), which is super useful. Our use case is to direct each event to a log_type that corresponds with the name of the application that emitted the log (a log event property).

However, the implementation as it currently stands appears to be broken. The current behaviour overwrites `@log_type` with the sprintf-ed version every time a different event is received. However, the events are batched and sent later. The batch of events is then sent to whatever the last value of `@log_type` is, which in my experience is just the desired log_type of the first event received by the class (since subsequent uses of `sprintf` don't find an actual format string in `@log_type` any more). `@log_type` is effectively a 'global' variable across all events, but the actual desired `log_type` varies on a per-event basis.

As such I've rewritten the implementation to derive a `log_type` from the format string in `@log_type` for each event during sending, group them by `log_type` and then send them.

I've also added back the `log_type` validation and enhanced it to check the current rules for log_type names (alphanumeric + underscores, max length 100).