### PR TITLE
Multithreading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ output {
         log_type => "<LOG TYPE NAME>"
         key_names  => ['key1','key2','key3'..] ## list of Key names
         key_types => {'key1'=> 'string' 'key2'=>'double' 'key3'=>'boolean' .. }
-        flush_items => <FLUSH_ITEMS_NUM>
-        flush_interval_time => <FLUSH INTERVAL TIME(sec)>
+        max_batch_items => <MAX BATCH ITEMS (num)>
     }
 }
 ```
@@ -37,8 +36,7 @@ output {
    * Multiple key value entries are separated by `spaces` rather than commas (See also [this](https://www.elastic.co/guide/en/logstash/current/configuration-file-structure.html#hash))
    * If you want to store a column as datetime or guid data format, set `string` for the column ( the value of the column should be `YYYY-MM-DDThh:mm:ssZ format` if it's `datetime`, and `GUID format` if it's `guid`).
    * In case that `key_types` param are not specified, all columns that you want to submit ( you choose with `key_names` param ) are stored as `string` data type in Log Analytics.
- * **flush_items (optional)** - Default 50. Max number of items to buffer before flushing (1 - 1000).
- * **flush_interval_time (optional)** - Default 5. Max number of seconds to wait between flushes.
+ * **max_batch_items (optional)** - Default 50. Maximum number of log events to put in one request to Log Analytics.
 
 > [NOTE] There is a special param for changing the Log Analytics API endpoint (mainly for supporting Azure sovereign cloud)
 > * **endpoint (optional)** - Default: ods.opinsights.azure.com 

--- a/spec/outputs/azure_loganalytics_spec.rb
+++ b/spec/outputs/azure_loganalytics_spec.rb
@@ -28,7 +28,7 @@ describe LogStash::Outputs::AzureLogAnalytics do
      azure_loganalytics_output.register
   end 
 
-  describe "#flush" do
+  describe "#multi_receive" do
     it "Should successfully send the event to Azure Log Analytics" do
       events = []
       log1 = {
@@ -61,11 +61,9 @@ describe LogStash::Outputs::AzureLogAnalytics do
 
       event1 =  LogStash::Event.new(log1) 
       event2 =  LogStash::Event.new(log2) 
-      azure_loganalytics_output.receive(event1)
-      azure_loganalytics_output.receive(event2)
       events.push(event1)
       events.push(event2)
-      expect {azure_loganalytics_output.flush(events)}.to_not raise_error
+      expect {azure_loganalytics_output.multi_receive(events)}.to_not raise_error
     end
   end
 


### PR DESCRIPTION
I've been working with the ability to send logs to multiple log_types for a couple of weeks now (#16), and have discovered the performance in certain scenarios is quite poor. In particular, if you have lots of logs coming in across a wide range of log_types then the number of logs you end up putting in a single HTTP request ends up being very low and you end up doing lots of tiny sequential requests which kills your throughput.

To fix this, I've made a few pretty fundamental changes to this plugin; the major one being introducing multithreading support. Logstash pipelines can support running multiple worker threads inside a pipeline and this is one way of speeding up throughput when you're waiting on the network (ie. do HTTP requests in parallel). Unfortunately the plugin didn't support multithreading and increasing worker threads just meant the multiple threads bottlenecked at the plugin anyway.

I've fixed this by removing the use of the internal buffer inside the plugin. This buffer is effectively single threaded as it has a critical section around access to the buffer itself (using an internal mutex). It turns out that Logstash itself already does buffering inside pipelines such that the settings `flush_items` and `flush_interval_time` roughly map to `pipeline.batch.size` and `pipeline.batch.delay` respectively. So I removed these settings and replaced them with a new one called `max_batch_items` which controls the maximum number of log events in a single HTTP request (what previously `flush_items` did before multiple `log_types` started splitting the batch into multiple HTTP requests). Logstash now delivers an entire batch of logs to the `multi_receive` method on the class, in parallel.

Performance wise, what I found was that by increasing my Logstash `pipeline.workers` and then increasing the `pipeline.batch.size` to thousands of log entries, I was able to increase the number of logs seen by the output at once, which made it more likely it could collect more logs belonging to a single log_type into HTTP request, but then `max_batch_items` meant that I still limited the number in any single batch to ensure I didn't exceed the Log Analytics API limits. And because of multithreading, I could do it all in parallel and further increase throughput in that fashion too.

I added a couple of debug log entries that log the start and end of a `multi_receive` (with a guid so you can correlate them when running in parallel). That made it easier for me to debug the batching behaviour and observe the parallel execution and batch sizes.

I realise this is a pretty fundamental change; I hope you're okay with accepting it! The `max_batch_items` parameter change is a breaking change to consumers, but honestly it should be breaking given how this change can radically affect performance. People should find out and retest their performance, not leap into it blindly, in my opinion. 😊